### PR TITLE
Add CI rollout baseline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,14 +13,10 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: "Build"
-    uses: dockette/.github/.github/workflows/docker.yml@master
-    secrets: inherit
-    with:
-        image: "dockette/deploy"
-        tag: "${{ matrix.tag }}"
-        context: "${{ matrix.context }}"
+  test:
+    name: "Test"
+    runs-on: "ubuntu-latest"
+
     strategy:
       matrix:
         include:
@@ -32,3 +28,58 @@ jobs:
             context: "deployer/v6"
 
       fail-fast: false
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v3
+
+      - name: "Build image"
+        uses: docker/build-push-action@v6
+        with:
+          context: "${{ matrix.context }}"
+          load: true
+          tags: "dockette/deploy:${{ matrix.tag }}"
+
+      - name: "Test image"
+        run: "make test-${{ matrix.tag }}"
+
+  build:
+    name: "Build"
+    needs: ["test"]
+    uses: dockette/.github/.github/workflows/docker.yml@master
+    secrets: inherit
+    with:
+      image: "dockette/deploy"
+      tag: "${{ matrix.tag }}"
+      context: "${{ matrix.context }}"
+    strategy:
+      matrix:
+        include:
+          - tag: "deployer8"
+            context: "deployer/v8"
+          - tag: "deployer7"
+            context: "deployer/v7"
+          - tag: "deployer6"
+            context: "deployer/v6"
+
+      fail-fast: false
+
+  docs:
+    name: "Docs"
+    runs-on: "ubuntu-latest"
+    needs: ["build"]
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Update Docker Hub description"
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: "dockette/deploy"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,15 @@
 DOCKER_IMAGE?=dockette/deploy
 DOCKER_PLATFORM?=linux/amd64
 
+.PHONY: build
+build: build-deployer8 build-deployer7 build-deployer6
+
+.PHONY: test
+test: test-deployer8 test-deployer7 test-deployer6
+
+.PHONY: run
+run: run-deployer8
+
 _docker-build:
 	docker buildx \
 		build \
@@ -9,14 +18,36 @@ _docker-build:
 		-t ${DOCKER_IMAGE}:${VERSION} \
 		./${CONTEXT}
 
+_docker-test:
+	docker run --rm ${DOCKER_IMAGE}:${VERSION} dep --version
+
+_docker-run:
+	docker run --rm -it -v ${PWD}:/srv ${DOCKER_IMAGE}:${VERSION}
+
 .PHONY: build-deployer6
 build-deployer6:
 	VERSION=deployer6 CONTEXT=deployer/v6 $(MAKE) _docker-build
 
 .PHONY: build-deployer7
-build-deployer7: 
+build-deployer7:
 	VERSION=deployer7 CONTEXT=deployer/v7 $(MAKE) _docker-build
 
 .PHONY: build-deployer8
-build-deployer8: 
+build-deployer8:
 	VERSION=deployer8 CONTEXT=deployer/v8 $(MAKE) _docker-build
+
+.PHONY: test-deployer6
+test-deployer6:
+	VERSION=deployer6 $(MAKE) _docker-test
+
+.PHONY: test-deployer7
+test-deployer7:
+	VERSION=deployer7 $(MAKE) _docker-test
+
+.PHONY: test-deployer8
+test-deployer8:
+	VERSION=deployer8 $(MAKE) _docker-test
+
+.PHONY: run-deployer8
+run-deployer8:
+	VERSION=deployer8 $(MAKE) _docker-run

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-# Deploy / Deployment Tools
+<h1 align=center>Dockette / Deploy</h1>
 
-[![Docker Stars](https://img.shields.io/docker/stars/dockette/deploy.svg?style=flat)](https://hub.docker.com/r/dockette/deploy/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/dockette/deploy.svg?style=flat)](https://hub.docker.com/r/dockette/deploy/)
+<p align=center>
+   <a href="https://github.com/dockette/deploy/actions"><img src="https://github.com/dockette/deploy/actions/workflows/docker.yml/badge.svg" alt="GitHub Actions"></a>
+   <a href="https://hub.docker.com/r/dockette/deploy"><img src="https://img.shields.io/docker/pulls/dockette/deploy.svg" alt="Docker Hub pulls"></a>
+   <a href="https://github.com/sponsors/f3l1x"><img src="https://img.shields.io/badge/sponsor-GitHub%20Sponsors-ea4aaa" alt="GitHub Sponsors"></a>
+   <a href="https://github.com/orgs/dockette/discussions"><img src="https://img.shields.io/badge/support-discussions-6f42c1" alt="Support/Discussions"></a>
+</p>
 
 ## Deployer
 
@@ -10,14 +14,14 @@
 
 | Version | Image |
 |---------|-------|
+| 8.x.x   | dockette/deploy:deployer8 |
 | 7.x.x   | dockette/deploy:deployer7 |
 | 6.x.x   | dockette/deploy:deployer6 |
-| 5.x.x   | dockette/deploy:deployer5 |
-| 4.x.x   | dockette/deploy:deployer4 |
 
 How to use it? Mount your app or just the deploy config.
 
 ```
+docker run -it --rm -v $(pwd)/deploy.php:/srv dockette/deploy:deployer8
 docker run -it --rm -v $(pwd)/deploy.php:/srv dockette/deploy:deployer7
 docker run -it --rm -v $(pwd)/deploy.php:/srv dockette/deploy:deployer6
 ```


### PR DESCRIPTION
## What changed
- Added a Test job before the reusable Build job for maintained Deployer 6/7/8 tags.
- Added Docker Hub README description publishing via a Docs job.
- Added baseline Makefile build, test, and run aliases while preserving deployer-specific build targets.
- Normalized README badges to the Dockette Copybara style and documented maintained Deployer tags only.

## Why
Aligns dockette/deploy with the Dockette CI rollout baseline for active Docker image repositories.